### PR TITLE
kalm

### DIFF
--- a/panik/__init__.py
+++ b/panik/__init__.py
@@ -6,6 +6,7 @@ Example:
     >>> import panik
     >>> sometim i paniks
 """
+import builtins
 import os
 import sys
 
@@ -15,4 +16,5 @@ __all__ = []
 with open(os.path.join(os.path.dirname(__file__), "panikman.txt")) as f:
     panik_img = "".join(f.readlines())
 
+builtins.kalm = None
 sys.excepthook = lambda *_: print(panik_img, file=sys.stderr)


### PR DESCRIPTION
`kalm` is now `kalm`

```sh
panik:kalm λ python
Python 3.9.1 (default, Feb  6 2021, 06:49:13) 
[GCC 10.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import panik
>>> kalm
```

![image](https://user-images.githubusercontent.com/6321485/111021519-fdba9d80-839a-11eb-85d1-6f3535b5b41a.png)


Fixes #1